### PR TITLE
test: add regression tests for past-match query window and reschedule detection

### DIFF
--- a/backend/services/match_watcher_service_sportsmonk.go
+++ b/backend/services/match_watcher_service_sportsmonk.go
@@ -173,7 +173,7 @@ func (m *MatchWatcherServiceSportsmonk) getMatchesUpdates() (map[string]models.M
 			matchesToQuery[id] = match
 		}
 	}
-	log.Infof("Getting last match infos for %d matches (out of %d watched, filtering to next 2 weeks)", len(matchesToQuery), len(m.watchedMatches))
+	log.Infof("Getting last match infos for %d matches (out of %d watched, excluding matches scheduled beyond 2 weeks in the future)", len(matchesToQuery), len(m.watchedMatches))
 	lastMatchInfos, err := m.repo.GetLastMatchInfos(matchesToQuery)
 	if err != nil {
 		return nil, err

--- a/backend/services/match_watcher_service_sportsmonk_test.go
+++ b/backend/services/match_watcher_service_sportsmonk_test.go
@@ -438,3 +438,74 @@ func TestMatchWatcherService_MatchBecomesRelevantAsTimeAdvances(t *testing.T) {
 	require.Len(t, mockRepo.receivedMatches, 2)
 	assert.Contains(t, mockRepo.receivedMatches[1], farMatch.Id())
 }
+
+func TestMatchWatcherService_QueriesPastMatchesThatMayBeRescheduled(t *testing.T) {
+	now := time.Date(2025, 1, 22, 0, 0, 0, 0, time.UTC)
+
+	pastMatch := models.NewSeasonMatch("Team1", "Team2", "2025", "Ligue 1", now.Add(-21*24*time.Hour), 1)  // 3 weeks ago
+	futureMatch := models.NewSeasonMatch("Team3", "Team4", "2025", "Ligue 1", now.Add(7*24*time.Hour), 2)  // 7 days ahead (control: included)
+	farFutureMatch := models.NewSeasonMatch("Team5", "Team6", "2025", "Ligue 1", now.Add(21*24*time.Hour), 3) // 21 days ahead (control: excluded)
+
+	mockRepo := &SportsmonkRepositoryMock{
+		lastMatchInfos: []map[string]models.Match{{}},
+	}
+
+	service := &MatchWatcherServiceSportsmonk{
+		watchedMatches: map[string]models.Match{
+			pastMatch.Id():      pastMatch,
+			futureMatch.Id():    futureMatch,
+			farFutureMatch.Id(): farFutureMatch,
+		},
+		repo:         mockRepo,
+		subscribers:  make(map[string]GameService),
+		stopChan:     make(chan struct{}),
+		pollInterval: 30 * time.Second,
+		matchRepo:    repositories.NewInMemoryMatchRepository(),
+		now:          func() time.Time { return now },
+	}
+
+	_, err := service.getMatchesUpdates()
+	require.NoError(t, err)
+	require.Len(t, mockRepo.receivedMatches, 1)
+	queried := mockRepo.receivedMatches[0]
+
+	assert.Contains(t, queried, pastMatch.Id(), "past-dated unfinished match must be queried so reschedules are detected")
+	assert.Contains(t, queried, futureMatch.Id())
+	assert.NotContains(t, queried, farFutureMatch.Id())
+	assert.Len(t, queried, 2)
+}
+
+func TestMatchWatcherService_DetectsRescheduleOfPastMatch(t *testing.T) {
+	now := time.Date(2025, 1, 22, 0, 0, 0, 0, time.UTC)
+	originalDate := now.Add(-21 * 24 * time.Hour)
+	rescheduledDate := now.Add(10 * 24 * time.Hour)
+
+	pastMatch := models.NewSeasonMatch("Team1", "Team2", "2025", "Ligue 1", originalDate, 1)
+	rescheduledMatch := models.NewSeasonMatch("Team1", "Team2", "2025", "Ligue 1", rescheduledDate, 1)
+
+	mockRepo := &SportsmonkRepositoryMock{
+		lastMatchInfos: []map[string]models.Match{
+			{pastMatch.Id(): rescheduledMatch},
+		},
+	}
+
+	service := &MatchWatcherServiceSportsmonk{
+		watchedMatches: map[string]models.Match{
+			pastMatch.Id(): pastMatch,
+		},
+		repo:         mockRepo,
+		subscribers:  make(map[string]GameService),
+		stopChan:     make(chan struct{}),
+		pollInterval: 30 * time.Second,
+		matchRepo:    repositories.NewInMemoryMatchRepository(),
+		now:          func() time.Time { return now },
+	}
+
+	updates, err := service.getMatchesUpdates()
+	require.NoError(t, err)
+	require.Len(t, updates, 1, "rescheduled past match must be reported as an update")
+	updatedMatch, ok := updates[pastMatch.Id()]
+	require.True(t, ok)
+	assert.Equal(t, rescheduledDate, updatedMatch.GetDate())
+	assert.Equal(t, rescheduledDate, service.watchedMatches[pastMatch.Id()].GetDate())
+}


### PR DESCRIPTION
A past-dated unfinished match (e.g. postponed without a Sportsmonk update)
must remain in the polling window so that rescheduled dates are detected.
The existing filter already includes past dates, but no tests covered this
path — leaving it vulnerable to accidental removal.

- Add TestMatchWatcherService_QueriesPastMatchesThatMayBeRescheduled:
  asserts past-dated matches are included in getMatchesUpdates() queries,
  alongside a future within-2-weeks control and a far-future exclusion control.
- Add TestMatchWatcherService_DetectsRescheduleOfPastMatch:
  asserts that when Sportsmonk returns a new future date for a past-dated
  scheduled match, matchWasUpdated detects the change and watchedMatches
  is updated accordingly.
- Fix misleading log message: "filtering to next 2 weeks" → "excluding
  matches scheduled beyond 2 weeks in the future" to prevent developers
  from introducing a spurious lower-bound cutoff.

https://claude.ai/code/session_016bKgBcS3xXnNR9ZrqsntVj